### PR TITLE
RFC 1341: default 'Content-Transfer-Encoding' to 7bit

### DIFF
--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -487,7 +487,7 @@ emlformat.read = function(eml, options, callback) {
       function _append(headers, content) {
         var contentType = headers["Content-Type"];
         var charset = getCharsetName(emlformat.getCharset(contentType) || defaultCharset);
-        var encoding = headers["Content-Transfer-Encoding"];
+        var encoding = headers["Content-Transfer-Encoding"] || "7bit";
         if (typeof encoding == "string") {
           encoding = encoding.toLowerCase();
         }


### PR DESCRIPTION
https://tools.ietf.org/html/rfc1341

>"Content-Transfer-Encoding:  7BIT"   is   assumed   if   the
>Content-Transfer-Encoding header field is not present.

Currently, the library will crash with `TypeError: Cannot read property 'startsWith' of undefined` if the `Content-Transfer-Encoding` header is missing.