### PR TITLE
fix unquotePrintable bug

### DIFF
--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -173,10 +173,10 @@ var emlformat = {
     //Convert =0D to '\r', =20 to ' ', etc.
     if (!charset || charset == "utf8" || charset == "utf-8") {
       return s
+      .replace(/=\r?\n/gi, "") //Join line
       .replace(/=([\w\d]{2})=([\w\d]{2})=([\w\d]{2})/gi, function(matcher, p1, p2, p3, offset, string) { return Buffer.from([ parseInt(p1, 16), parseInt(p2, 16), parseInt(p3, 16) ]).toString("utf8"); })
       .replace(/=([\w\d]{2})=([\w\d]{2})/gi, function(matcher, p1, p2, offset, string) { return Buffer.from([ parseInt(p1, 16), parseInt(p2, 16) ]).toString("utf8"); })
-      .replace(/=([\w\d]{2})/gi, function(matcher, p1, offset, string) { return String.fromCharCode(parseInt(p1, 16)); })
-      .replace(/=\r?\n/gi, ""); //Join line
+      .replace(/=([\w\d]{2})/gi, function(matcher, p1, offset, string) { return String.fromCharCode(parseInt(p1, 16)); });
     }
     else {
       return s


### PR DESCRIPTION
Test string
```
测试测试测tes试测试测试
```

QP encoding
```
=E6=B5=8B=E8=AF=95=E6=B5=8B=E8=AF=95=E6=B5=8Btes=E8=AF=95=E6=B5=8B=E8=AF=
=95=E6=B5=8B=E8=AF=95
```

Test Code
```
const emlformat = require('eml-format');
let message = emlformat.unquotePrintable(
  `=E6=B5=8B=E8=AF=95=E6=B5=8B=E8=AF=95=E6=B5=8Btes=E8=AF=95=E6=B5=8B=E8=AF=
=95=E6=B5=8B=E8=AF=95`
);

console.log(message).toString('hex'))
```
result
```
测试测试测tes试测�����
```