### PR TITLE
Use "Content-Transfer-Encoding" header defined in the mail if a multipart does not include this header

### DIFF
--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -487,7 +487,7 @@ emlformat.read = function(eml, options, callback) {
       function _append(headers, content) {
         var contentType = headers["Content-Type"];
         var charset = getCharsetName(emlformat.getCharset(contentType) || defaultCharset);
-        var encoding = headers["Content-Transfer-Encoding"];
+        var encoding = headers["Content-Transfer-Encoding"] || results.headers["Content-Transfer-Encoding"];
         if (typeof encoding == "string") {
           encoding = encoding.toLowerCase();
         }

--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -487,7 +487,7 @@ emlformat.read = function(eml, options, callback) {
       function _append(headers, content) {
         var contentType = headers["Content-Type"];
         var charset = getCharsetName(emlformat.getCharset(contentType) || defaultCharset);
-        var encoding = headers["Content-Transfer-Encoding"] || results.headers["Content-Transfer-Encoding"];
+        var encoding = headers["Content-Transfer-Encoding"] || result.headers["Content-Transfer-Encoding"];
         if (typeof encoding == "string") {
           encoding = encoding.toLowerCase();
         }


### PR DESCRIPTION
See #21 for more details