### PR TITLE
fixed Unable to get html source of an email

### DIFF
--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -522,6 +522,13 @@ emlformat.read = function(eml, options, callback) {
           //Plain text message
           result.text = content;
         }
+        else if(!result.text && contentType && contentType.indexOf("multipart") >= 0) {
+          if(Array.isArray(content)){
+            for(var i=0;i<content.length;i++){
+                _append(content[i].part.headers, content[i].part.body);
+            }
+          }
+        }
         else {
           //Get the attachment
           if (!result.attachments) {


### PR DESCRIPTION
When content is a nested array, the html bug cannot be parsed