### PR TITLE
Add BCC support 

### DIFF
--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -354,7 +354,11 @@ emlformat.build = function(data, options, callback) {
     if (typeof data.cc != "undefined") {
       data.headers["Cc"] = (typeof data.cc == "string" ? data.cc : emlformat.toEmailAddress(data.cc));
     }
-    
+
+    if (typeof data.bcc != "undefined") {
+      data.headers["Bcc"] = (typeof data.bcc == "string" ? data.bcc : emlformat.toEmailAddress(data.bcc));
+    }
+
     if (!data.headers["To"]) {
       throw new Error("Missing 'To' e-mail address!");
     }
@@ -481,6 +485,13 @@ emlformat.read = function(eml, options, callback) {
       if (data.headers["Cc"]) {
         result.cc = emlformat.getEmailAddress(data.headers["Cc"]);
       }
+      if (data.headers["BCC"]) {
+        result.bcc = emlformat.getEmailAddress(data.headers["BCC"]);
+      }
+      if (data.headers["Bcc"]) {
+        result.bcc = emlformat.getEmailAddress(data.headers["Bcc"]);
+      }
+
       result.headers = data.headers;
       
       //Appends the boundary to the result


### PR DESCRIPTION
This is the same as #12 but for BCC. Note that support for `data.headers["BCc"]` was not added.